### PR TITLE
fix sweetAlert2 vulnerability (GHSA-qq6h-5g6j-q3cm)

### DIFF
--- a/FrontEnd/package-lock.json
+++ b/FrontEnd/package-lock.json
@@ -18,7 +18,7 @@
         "react-icons": "^4.8.0",
         "react-router-dom": "^6.11.0",
         "react-toastify": "^9.1.2",
-        "sweetalert2": "^11.7.5"
+        "sweetalert2": "^11.4.8"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -20,7 +20,7 @@
     "react-icons": "^4.8.0",
     "react-router-dom": "^6.11.0",
     "react-toastify": "^9.1.2",
-    "sweetalert2": "^11.7.5"
+    "sweetalert2": "^11.4.8"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",


### PR DESCRIPTION
downgraded sweetAlert2 package to version 11.4.8 to mitigate the vulnerability